### PR TITLE
Run ESLint against .js files in root dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "package": "npm-run-all clean:extension build:extension && web-ext build --overwrite-dest --source-dir=build/extension && mv web-ext-artifacts/*.zip ./addon.xpi",
     "sign": "npm-run-all clean:extension build:extension && web-ext sign --source-dir=build/extension && mv web-ext-artifacts/*.xpi ./addon.xpi",
     "run": "npm run build:extension && web-ext run --source-dir=build/extension",
-    "lint": "eslint --color src",
+    "lint": "eslint --color .",
     "test": "npm run lint",
     "deploy": "gh-pages -d build/web",
     "release:base": "npm-run-all clean build:web sign && mv addon.xpi build/web && npm run deploy",


### PR DESCRIPTION
Oops, this should have been included in an earlier PR.
We already checked in an .eslintignore file which skips the generated ./build/ directory.